### PR TITLE
Hitfix for cloud transparency bug

### DIFF
--- a/src/materials/PointCloudMaterial.js
+++ b/src/materials/PointCloudMaterial.js
@@ -294,6 +294,7 @@ Potree.PointCloudMaterial = class PointCloudMaterial extends THREE.RawShaderMate
 			this.transparent = false;
 			this.depthTest = true;
 			this.depthWrite = true;
+			this.depthFunc = THREE.LessEqualDepth;
 		} else if (this.opacity < 1.0 && !this.useEDL) {
 			this.blending = THREE.AdditiveBlending;
 			this.transparent = true;


### PR DESCRIPTION
When transparency was set lower to one, this.depthFunc = THREE.AlwaysDepth, but it was then not set back to THREE.LessEqualDepth when cloud opacity/alpha was equal to 1 again.